### PR TITLE
tool_paramhlp.c: Remove logically unreachable code.

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -490,8 +490,6 @@ ParameterError add2list(struct curl_slist **list, const char *ptr)
     *list = newlist;
   else
     return PARAM_NO_MEM;
-
-  return PARAM_OK;
 }
 
 int ftpfilemethod(struct OperationConfig *config, const char *str)


### PR DESCRIPTION
Since the ```else``` branch already returns ```PARAM_NO_MEM```  the last return statement (```return PARAM_OK```) becomes unreachable.